### PR TITLE
Use clusterID and node name when providerID is missing

### DIFF
--- a/cluster-autoscaler/cloudprovider/rancher/rancher_manager.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_manager.go
@@ -111,6 +111,10 @@ func (m *manager) getNodePools() (map[string]rancher.NodePool, error) {
 }
 
 func (m *manager) getNode(node *apiv1.Node) (*rancher.Node, error) {
-	klog.Infof("Trying to get Node by ProviderID %q", node.Spec.ProviderID)
-	return m.client.NodeByProviderID(node.Spec.ProviderID)
+	if node.Spec.ProviderID != "" {
+		klog.Infof("Trying to get Node by ProviderID %q", node.Spec.ProviderID)
+		return m.client.NodeByProviderID(node.Spec.ProviderID)
+	}
+	klog.Infof("Looking up node using clusterID %q and node name %q", m.clusterID, node.Name)
+	return m.client.NodeByNameAndCluster(node.Name, m.clusterID)
 }


### PR DESCRIPTION
Minor tweak to fall back to clusterID and node name to lookup node.

Useful for RKE clusters provisioned without a cloud provider